### PR TITLE
Zone Layout and Component Card Styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 
 # Coverage reports
 coverage/
+
+# Assets
+assets/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,8 +202,10 @@ Any failure blocks the merge.
 
 To add a new component type (e.g., `weather`):
 
-1. Write a builder function: `buildWeather(component, id)` →  returns a `div.component-card` with `data-component-id` set to `id`
-   - All other structure is type-specific but contain inside the component-card
+1. build[Type](component, id) → div.component-card
+  - Root is always a div with class="component-card"
+  - data-component-id is stamped on that root div
+  - All inner content elements are children of the card div
 2. Register it: add `['weather', buildWeather]` to the component registry
 3. Add a corresponding entry to `config.json` with `"type": "weather"`
 4. Write unit tests for `buildWeather` before or alongside implementation (TDD)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ The human developers on this team are taking the lead on writing code and tests.
 
 **Provide code snippets when appropriate.** Short examples that illustrate a concept or pattern are helpful. The distinction is between "here's how fetch works" (educational) versus "here's your entire function" (doing the work for them).
 
+**"Write documentation."** — Create comprehensive documentation to reflect design decisions
+
 ---
 
 ## What Claude Should Avoid
@@ -65,7 +67,7 @@ digital-signage-renderer/
 |---|---|
 | **Config Loader** | `fetch`es and validates `config.json`; rejects on missing required fields |
 | **Component Registry** | A `Map` of `type → builderFunction`; adding a new component = registering one function |
-| **Component Builders** | One pure function per type (buildClock, buildRSS, buildImage, buildText, buildWeather). Signature: build[Type](component, id) — takes the component config object and a unique string ID, sets data-component-id on the root element, returns that element. These are the unit-testable surface. |
+| **Component Builders** | One pure function per type (buildClock, buildRSS, buildImage, buildText, buildWeather). Signature: build[Type](component, id) — takes the component config object and a unique string ID. Returns a div.component-card with data-component-id set to id as the root element. The card div wraps all inner content elements and is responsible for card styling. This consistent root structure allows the Scheduler to locate and replace any component type via [data-component-id] without knowing the component's internal structure. These are the unit-testable surface. |
 | **Scheduler** | Handles per-component refresh intervals using `setInterval`; respects the `refresh` field in config |
 | **Bootstrap** | Entry point — wires everything together on `DOMContentLoaded`. Iterates config components, calls registry, injects into zones, starts scheduler. |
 
@@ -200,9 +202,8 @@ Any failure blocks the merge.
 
 To add a new component type (e.g., `weather`):
 
-1. Write a builder function: `buildWeather(component, id)` → returns a DOM element
-   - The element must have `data-component-id` set to `id`
-   - All other structure is type-specific
+1. Write a builder function: `buildWeather(component, id)` →  returns a `div.component-card` with `data-component-id` set to `id`
+   - All other structure is type-specific but contain inside the component-card
 2. Register it: add `['weather', buildWeather]` to the component registry
 3. Add a corresponding entry to `config.json` with `"type": "weather"`
 4. Write unit tests for `buildWeather` before or alongside implementation (TDD)

--- a/src/index.html
+++ b/src/index.html
@@ -7,10 +7,11 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <div id="header" class="zone"></div>
-  <div id="main" class="zone"></div>
-  <div id="sidebar" class="zone"></div>
-  <div id="footer" class="zone"></div>
-
+  <div id="display-root">
+    <div id="header" class="zone"></div>
+    <div id="main" class="zone"></div>
+    <div id="sidebar" class="zone"></div>
+    <div id="footer" class="zone"></div>
+  </div>
   <script type="module" src="renderer.js"></script>
 </body>

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Digital Signage</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <div id="display-root">

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -175,11 +175,24 @@ function getComponent(type) {
 // Input: config object  Output: DOM element
 // These are the unit-testable surface
 // ============================================================
-function buildImage(component){
+
+/**
+ * Builds an image component
+ * @param {Object} component 
+ * @param {String} id 
+ * @returns {HTMLElement}
+ */
+function buildImage(component, id) {
+    const card = document.createElement('div');
+    card.className = 'component-card';
+    card.dataset.componentId = id;
+
     const img = document.createElement('img');
     img.setAttribute('src', component.src);
     img.setAttribute('alt', component.alt);
-    return img;
+
+    card.appendChild(img);
+    return card;
 }
 
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -133,7 +133,7 @@ function registerComponents() {
     // To register a new component add it below
     // ex. registerComponent('type', buildType)
     // registerComponent('rss', buildRss);
-    // registerComponent('image', buildImage);
+    registerComponent('image', buildImage);
 }
 
 /**
@@ -209,6 +209,9 @@ async function bootstrap() {
     try {
         const validZones = Array.from(document.querySelectorAll('.zone')).map(el => el.id);
         const config = await loadConfig(validZones);
+        document.documentElement.style.setProperty('--color-bg', config.theme?.background ?? '#111111');
+        document.documentElement.style.setProperty('--color-text', config.theme?.color ?? '#ffffff');
+        document.documentElement.style.setProperty('--font-family', config.theme?.fontFamily ?? 'sans-serif');
         registerComponents();
         for (const [i, component] of config.components.entries()) {
             const builder = getComponent(component.type);

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,59 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  font-size: 1.5vw;
+}
+
+#display-root {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  grid-template-columns: 1fr 4fr;
+  grid-template-rows: 1fr 6fr 1fr;
+  grid-template-areas:
+    "header  header"
+    "sidebar main"
+    "footer  footer";
+  gap: 0.5em;
+  padding: 0.5em;
+  background-color: var(--color-bg, #111111);
+}
+
+#header  { grid-area: header; }
+#sidebar { grid-area: sidebar; }
+#main    { grid-area: main; }
+#footer  { grid-area: footer; }
+
+.zone {
+  background-color: color-mix(in srgb, var(--color-bg, #111111) 85%, white);
+  color: var(--color-text, #ffffff);
+  font-family: var(--font-family, sans-serif);
+  padding: 1em;
+  overflow: hidden;
+  border-radius: 0.4em;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}
+
+#display-root {
+  background-color: var(--color-bg, #111111);
+}
+
+#header, #footer {
+  flex-direction: row;
+}
+
+.zone img {
+ width: 100%;
+  flex: 1;
+  object-fit: cover;
+  min-height: 0;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,7 @@
+/* ============================================================
+   RESET
+   Normalize browser defaults for consistent cross-browser rendering
+   ============================================================ */
 *, *::before, *::after {
   box-sizing: border-box;
 }
@@ -7,10 +11,15 @@ html, body {
   padding: 0;
   width: 100%;
   height: 100%;
-  overflow: hidden;
-  font-size: 1.5vw;
+  overflow: hidden; /* Prevent scrollbars on a fixed signage display */
+  font-size: 1.5vw; /* Base font scaled to viewport width for distance readability */
 }
 
+/* ============================================================
+   ROOT LAYOUT
+   CSS Grid container — defines zone positions and gutters
+   Theme background set here; zone cards use a lighter variant
+   ============================================================ */
 #display-root {
   display: grid;
   width: 100%;
@@ -26,11 +35,20 @@ html, body {
   background-color: var(--color-bg, #111111);
 }
 
+/* ============================================================
+   ZONE PLACEMENT
+   Assigns each zone element to its named grid area
+   ============================================================ */
 #header  { grid-area: header; }
 #sidebar { grid-area: sidebar; }
 #main    { grid-area: main; }
 #footer  { grid-area: footer; }
 
+/* ============================================================
+   ZONE BASE
+   Zones are invisible layout containers — no background or border
+   Visual card treatment lives on .component-card, not the zone
+   ============================================================ */
 .zone {
   color: var(--color-text, #ffffff);
   font-family: var(--font-family, sans-serif);
@@ -40,16 +58,19 @@ html, body {
   gap: 0.5em;
 }
 
-#display-root {
-    background-color: var(--color-bg, #111111);
-}
-
+/* Header and footer stack children horizontally */
 #header, #footer {
-    flex-direction: row;
+  flex-direction: row;
 }
 
+/* ============================================================
+   COMPONENT CARD
+   Visual card surface for every component type
+   flex: 1 ensures equal space sharing between sibling cards
+   min-height: 0 allows flex children to shrink below natural size
+   ============================================================ */
 .component-card {
-  background-color: color-mix(in srgb, var(--color-bg, #111111) 85%, white);
+  background-color: color-mix(in srgb, var(--color-bg, #111111) 85%, white); /* Slightly lighter than root background */
   display: flex;
   border-radius: 0.4em;
   padding: 0.5em;
@@ -57,6 +78,11 @@ html, body {
   min-height: 0;
 }
 
+/* ============================================================
+   COMPONENT-SPECIFIC STYLES
+   ============================================================ */
+
+/* Images fill their card while preserving aspect ratio */
 .component-card img {
   width: 100%;
   height: 100%;

--- a/src/style.css
+++ b/src/style.css
@@ -16,7 +16,7 @@ html, body {
   width: 100%;
   height: 100%;
   grid-template-columns: 1fr 4fr;
-  grid-template-rows: 1fr 6fr 1fr;
+  grid-template-rows: 1fr 5fr 1fr;
   grid-template-areas:
     "header  header"
     "sidebar main"
@@ -32,28 +32,35 @@ html, body {
 #footer  { grid-area: footer; }
 
 .zone {
-  background-color: color-mix(in srgb, var(--color-bg, #111111) 85%, white);
   color: var(--color-text, #ffffff);
   font-family: var(--font-family, sans-serif);
-  padding: 1em;
   overflow: hidden;
-  border-radius: 0.4em;
   display: flex;
   flex-direction: column;
   gap: 0.5em;
 }
 
 #display-root {
-  background-color: var(--color-bg, #111111);
+    background-color: var(--color-bg, #111111);
 }
 
 #header, #footer {
-  flex-direction: row;
+    flex-direction: row;
 }
 
-.zone img {
- width: 100%;
+.component-card {
+  background-color: color-mix(in srgb, var(--color-bg, #111111) 85%, white);
+  display: flex;
+  border-radius: 0.4em;
+  padding: 0.5em;
   flex: 1;
+  min-height: 0;
+}
+
+.component-card img {
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   min-height: 0;
+  flex: 1;
 }

--- a/test/builders.test.js
+++ b/test/builders.test.js
@@ -3,21 +3,37 @@ import { buildImage } from '../src/renderer.js';
 
 describe('buildImage', () => {
 
-    it('should set the src attribute', () => {
+    it('should return a component-card wrapper div', () => {
         const component = { src: './assets/logo.png', alt: 'A logo' };
-        const result = buildImage(component);
-        expect(result.getAttribute('src')).toBe('./assets/logo.png');
+        const result = buildImage(component, 'component-0');
+        expect(result.tagName).toBe('DIV');
+        expect(result.classList.contains('component-card')).toBe(true);
     });
 
-    it('should set the alt attribute', () => {
+    it('should stamp data-component-id on the card', () => {
         const component = { src: './assets/logo.png', alt: 'A logo' };
-        const result = buildImage(component);
-        expect(result.getAttribute('alt')).toBe('A logo');
+        const result = buildImage(component, 'component-0');
+        expect(result.dataset.componentId).toBe('component-0');
     });
 
-    it('should create an img element', () => {
+    it('should contain an img element inside the card', () => {
         const component = { src: './assets/logo.png', alt: 'A logo' };
-        const result = buildImage(component);
-        expect(result.tagName).toBe('IMG');
+        const result = buildImage(component, 'component-0');
+        const img = result.querySelector('img');
+        expect(img).not.toBeNull();
+    });
+
+    it('should set the src attribute on the img', () => {
+        const component = { src: './assets/logo.png', alt: 'A logo' };
+        const result = buildImage(component, 'component-0');
+        const img = result.querySelector('img');
+        expect(img.getAttribute('src')).toBe('./assets/logo.png');
+    });
+
+    it('should set the alt attribute on the img', () => {
+        const component = { src: './assets/logo.png', alt: 'A logo' };
+        const result = buildImage(component, 'component-0');
+        const img = result.querySelector('img');
+        expect(img.getAttribute('alt')).toBe('A logo');
     });
 });


### PR DESCRIPTION
## Summary
Implements the full CSS layout for the digital signage renderer and establishes the component card pattern — zones are invisible grid containers, each component renders as its own styled card.

## Changes Made

**`styles.css` (new)**
- Reset and base styles: `box-sizing: border-box`, margin/padding wipe on `html`/`body`, `overflow: hidden` for signage display, `font-size: 1.5vw` for distance-readable type
- `#display-root` — CSS Grid with named template areas, `1fr/4fr` column split, `1fr/6fr/1fr` row split, `gap` and `padding` for gutters
- Zone placement rules: `#header`, `#sidebar`, `#main`, `#footer` assigned to grid areas
- `.zone` — invisible flex container (no background, no border-radius); `flex-direction: column` by default, overridden to `row` for `#header` and `#footer`
- `.component-card` — card styling with `color-mix` lightened background, `border-radius`, `padding`, `flex: 1`, `min-height: 0`; serves as the visual card surface for every component
- `.component-card img` — fills card via `width: 100%`, `height: 100%`, `object-fit: cover`, `flex: 1`, `min-height: 0`
- CSS custom properties (`--color-bg`, `--color-text`, `--font-family`) consumed from theme config set by bootstrap at runtime; all rules include fallback defaults

**`renderer.js`**
- `buildImage` updated to return a `div.component-card` wrapping the `img` element, with `data-component-id` stamped on the card root — consistent with updated builder contract
- Bootstrap updated to set CSS custom properties from `config.theme` after `loadConfig` resolves, using optional chaining (`?.`) and nullish coalescing (`??`) for safe fallback handling
- Fixed "Cannot access config before initialization" bug — theme property assignment moved to after `const config = await loadConfig(validZones)`

**`index.html`**
- Added `#display-root` wrapper div as the CSS Grid container parent for all zone elements

**`CLAUDE.md`**
- Updated Component Builders section to document the new `div.component-card` root contract
- Updated Component Extension Guide step 1 to reflect card wrapper requirement

## Implementation Notes
- CSS custom properties are set by JS at runtime from config theme values; CSS `var()` fallbacks ensure the display is never unstyled even if theme is omitted from config
- Zones are intentionally unstyled — they are layout primitives only; all visual card treatment lives on `.component-card`
- `color-mix(in srgb, var(--color-bg) 85%, white)` produces a consistently lighter card surface relative to whatever background color the config provides
- `min-height: 0` on both `.component-card` and `.component-card img` is required to allow flex children to shrink below their natural content size

## Testing
- Manually verified layout at full browser width with 2 images in main (column), 2 images in header (row), and single images in sidebar and footer
- Verified external image URLs load correctly alongside local asset paths
- No unit tests required for `styles.css`; `buildImage` contract change is covered by revised builder tests

## Definition of Done
- [x] No known defects
- [x] 90%+ unit test coverage
- [x] 100% JSDoc documented
- [x] User documentation up to date
- [x] Code reviewed via pull request