### PR TITLE
Feature/scheduler

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -405,11 +405,15 @@ function drawAnalogClock() {
  * @param {Object} component The component configuration object to render
  * @param {HTMLElement} zoneElem the targetzone DOM element
  */
-function renderComponent(component, zoneElem, id) {
+async function renderComponent(component, zoneElem, id) {
     const builder = getComponent(component.type);
-    const element = builder(component, id);
-    zoneElem.innerHTML = '';
-    zoneElem.appendChild(element);
+    const element = await builder(component, id);
+    const existing = zoneElem.querySelector(`[data-component-id="${id}"]`);
+    if (existing) {
+        zoneElem.replaceChild(element, existing);
+    } else {
+        zoneElem.appendChild(element);
+    }
 }
 
 /**
@@ -429,8 +433,8 @@ function scheduleComponent(component, zoneElem, id) {
     if (typeof component.refresh !== 'number' || component.refresh <= 0) {
         return { intervalId: null, cancel() {} };
     }
-    const intervalId = setInterval(() => {
-        renderComponent(component, zoneElem, id);
+    const intervalId = setInterval(async () => {
+        await renderComponent(component, zoneElem, id);
     }, component.refresh);
     return {
         intervalId,
@@ -477,7 +481,7 @@ async function bootstrap() {
         for (const [i, component] of config.components.entries()) {
             const id = `component-${i}`;
             const zoneElem = zoneElems.get(component.zone);
-            renderComponent(component, zoneElem, id);
+            await renderComponent(component, zoneElem, id);
             if (component.refresh) {
                 scheduleComponent(component, zoneElem, id);
             }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -399,6 +399,57 @@ function drawAnalogClock() {
 // ============================================================
 /* istanbul ignore next */
 
+/**
+ * Rendes a single component into the target zone
+ * Clears the zones exsisting content and bulds the DOm elemetn and appends it
+ * @param {Object} component The component configuration object to render
+ * @param {HTMLElement} zoneElem the targetzone DOM element
+ */
+function renderComponent(component, zoneElem, id) {
+    const builder = getComponent(component.type);
+    const element = builder(component, id);
+    zoneElem.innerHTML = '';
+    zoneElem.appendChild(element);
+}
+
+/**
+ * Schedules a component to be rendered and an optional periodic refresh
+ * 
+ * - Renders the component immediately on call
+ * - If the 'component.refresh' is a positive number, it sets up a repeating interval that re-renders the component at that cadence
+ * - Returns a cleanup handle so callers can cancel the interval later 
+ * 
+ * @param {Object} component The component config object
+ * @param {HTMLElement} zoneElem the target zone DOM element
+ * @returns {Object} An object with intervalId and cancel properties
+ * @returns {(number|null)} intervalId - The value returned by setInterval, or null if no interval was created
+ * @returns {Function} cancel - A zero-argument function that stops the interval
+ */
+function scheduleComponent(component, zoneElem, id) {
+    if (typeof component.refresh !== 'number' || component.refresh <= 0) {
+        return { intervalId: null, cancel() {} };
+    }
+    const intervalId = setInterval(() => {
+        renderComponent(component, zoneElem, id);
+    }, component.refresh);
+    return {
+        intervalId,
+        cancel() {
+            clearInterval(intervalId);
+        }
+    };
+}
+
+/**
+ * Cancels all active scheduler handles returned by bootstrap
+ * Safe to call multiple times; already-cancelled handles are no-ops
+ * @param {Array<{ cancel: Function }>} handles
+ */
+function cancelAll(handles) {
+    for (const handle of handles) {
+        handle.cancel();
+    }
+}
 
 
 // ============================================================
@@ -415,19 +466,20 @@ function drawAnalogClock() {
 /* istanbul ignore next */
 async function bootstrap() {
     try {
-        const validZones = Array.from(document.querySelectorAll('.zone')).map(el => el.id);
-        const config = await loadConfig(validZones);
+        const zoneElems = new Map(Array.from(document.querySelectorAll('.zone')).map(el => [el.id, el]));
+        const config = await loadConfig(Array.from(zoneElems.keys()));
         document.documentElement.style.setProperty('--color-bg', config.theme?.background ?? '#111111');
         document.documentElement.style.setProperty('--color-text', config.theme?.color ?? '#ffffff');
         document.documentElement.style.setProperty('--color-secondary', config.theme?.secondaryColor ?? '#888888');
         document.documentElement.style.setProperty('--font-family', config.theme?.fontFamily ?? 'sans-serif');
         registerComponents();
+
         for (const [i, component] of config.components.entries()) {
-            const builder = getComponent(component.type);
-            const element = await builder(component, `component-${i}`);
-            document.getElementById(component.zone).appendChild(element);
+            const id = `component-${i}`;
+            const zoneElem = zoneElems.get(component.zone);
+            renderComponent(component, zoneElem, id);
             if (component.refresh) {
-                // Call the scheduler to set up refresh intervals for this component
+                scheduleComponent(component, zoneElem, id);
             }
         }
     }
@@ -452,6 +504,9 @@ export { loadConfig,
     buildImage,
     bootstrap,
     buildClock,
+    scheduleComponent,
+    cancelAll,
+    renderComponent,
     buildWeather,
     fetchWeatherData,
 };

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -410,7 +410,7 @@ async function renderComponent(component, zoneElem, id) {
     const element = await builder(component, id);
     const existing = zoneElem.querySelector(`[data-component-id="${id}"]`);
     if (existing) {
-        zoneElem.replaceChild(element, existing);
+        existing.replaceWith(element);
     } else {
         zoneElem.appendChild(element);
     }

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -27,19 +27,20 @@ function clearDOM() {
     document.body.innerHTML = '';
 }
 
-/** A minimal builder stub that returns a <span> containing a counter value. */
+/** A minimal builder stub that returns a <span> containing a counter value, with data-component-id stamped. */
 function makeBuilder(label = 'item') {
     let count = 0;
-    const build = jest.fn(() => {
+    const build = jest.fn((_component, id) => {
         const span = document.createElement('span');
         span.textContent = `${label}-${++count}`;
+        span.dataset.componentId = id;
         return span;
     });
     return build;
 }
 
 // ==============================================================================
-//                                  SETOUP
+//                                   SETUP
 // ==============================================================================
 
 beforeEach(() => {
@@ -62,14 +63,14 @@ afterEach(() => {
 // ==============================================================================
 
 describe('renderComponent', () => {
-    test('calls the registered builder and appends the result to the zone', () => {
+    test('calls the registered builder and appends the result to the zone', async () => {
         const builder = jest.fn(() => document.createElement('img'));
         registerComponent('photo', builder);
 
         const zone = createZone('z1');
         const component = { type: 'photo', zone: 'z1' };
 
-        renderComponent(component, zone);
+        await renderComponent(component, zone);
 
         expect(builder).toHaveBeenCalledTimes(1);
         expect(builder).toHaveBeenCalledWith(component, undefined);
@@ -77,30 +78,40 @@ describe('renderComponent', () => {
         expect(zone.children[0].tagName).toBe('IMG');
     });
 
-    test('clears existing zone content before appending the new element', () => {
+    test('replaces the existing card by data-component-id, leaving other zone children intact', async () => {
         const zone = createZone('z2');
-        zone.innerHTML = '<p>old content</p><p>more old content</p>';
 
-        registerComponent('clean', () => document.createElement('span'));
-        renderComponent({ type: 'clean', zone: 'z2' }, zone);
+        const other = document.createElement('div');
+        other.dataset.componentId = 'component-99';
+        zone.appendChild(other);
 
-        expect(zone.children).toHaveLength(1);
-        expect(zone.querySelector('p')).toBeNull();
+        registerComponent('clean', () => {
+            const el = document.createElement('span');
+            el.dataset.componentId = 'component-0';
+            return el;
+        });
+
+        await renderComponent({ type: 'clean', zone: 'z2' }, zone, 'component-0');
+        await renderComponent({ type: 'clean', zone: 'z2' }, zone, 'component-0');
+
+        expect(zone.children).toHaveLength(2); // other card still present
+        expect(zone.querySelector('[data-component-id="component-99"]')).not.toBeNull();
+        expect(zone.querySelector('[data-component-id="component-0"]').tagName).toBe('SPAN');
     });
 
-    test('throws when the component type has no registered builder', () => {
+    test('throws when the component type has no registered builder', async () => {
         const zone = createZone('z3');
-        expect(() =>
+        await expect(
             renderComponent({ type: 'unregistered', zone: 'z3' }, zone)
-        ).toThrow(/unregistered/);
+        ).rejects.toThrow(/unregistered/);
     });
 
-    test('renders on every call (called multiple times, zone always has one child)', () => {
+    test('replaces the same card on repeated renders, not appending duplicates', async () => {
         const zone = createZone('z4');
         registerComponent('counter', makeBuilder('c'));
 
         for (let i = 0; i < 5; i++) {
-            renderComponent({ type: 'counter', zone: 'z4' }, zone);
+            await renderComponent({ type: 'counter', zone: 'z4' }, zone, 'component-0');
             expect(zone.children).toHaveLength(1);
         }
     });
@@ -305,7 +316,7 @@ describe('cancelAll', () => {
         const zone2 = createZone('ca6');
 
         const h1 = scheduleComponent({ type: 'ind', zone: 'ca5', refresh: 300 }, zone1, 'component-0');
-        const h2 = scheduleComponent({ type: 'ind', zone: 'ca6', refresh: 300 }, zone2, 'component-1');
+        scheduleComponent({ type: 'ind', zone: 'ca6', refresh: 300 }, zone2, 'component-1');
 
         h1.cancel();
         jest.advanceTimersByTime(900); // 3 ticks

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -1,0 +1,316 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+    renderComponent,
+    scheduleComponent,
+    cancelAll,
+    registerComponent,
+} from '../src/renderer.js';
+
+// ==================================================================================
+//                                   HELPERS
+// ==================================================================================
+
+/** Creates a detached div and adds it to the document with a given id. */
+function createZone(id) {
+    const el = document.createElement('div');
+    el.id = id;
+    document.body.appendChild(el);
+    return el;
+}
+
+/** Removes every child of document.body between tests. */
+function clearDOM() {
+    document.body.innerHTML = '';
+}
+
+/** A minimal builder stub that returns a <span> containing a counter value. */
+function makeBuilder(label = 'item') {
+    let count = 0;
+    const build = jest.fn(() => {
+        const span = document.createElement('span');
+        span.textContent = `${label}-${++count}`;
+        return span;
+    });
+    return build;
+}
+
+// ==============================================================================
+//                                  SETOUP
+// ==============================================================================
+
+beforeEach(() => {
+    jest.useFakeTimers();
+    clearDOM();
+    // Register the two built-in types used across tests
+    registerComponent('image', makeBuilder('image'));
+    registerComponent('widget', makeBuilder('widget'));
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+    // Clear the registry so tests don't bleed into each other.
+    // We reach into the module-level Map via getComponent's closure; the
+    // simplest way is to re-register with a fresh stub in each beforeEach.
+});
+
+// ==============================================================================
+//                                RENDER COMPONENT
+// ==============================================================================
+
+describe('renderComponent', () => {
+    test('calls the registered builder and appends the result to the zone', () => {
+        const builder = jest.fn(() => document.createElement('img'));
+        registerComponent('photo', builder);
+
+        const zone = createZone('z1');
+        const component = { type: 'photo', zone: 'z1' };
+
+        renderComponent(component, zone);
+
+        expect(builder).toHaveBeenCalledTimes(1);
+        expect(builder).toHaveBeenCalledWith(component, undefined);
+        expect(zone.children).toHaveLength(1);
+        expect(zone.children[0].tagName).toBe('IMG');
+    });
+
+    test('clears existing zone content before appending the new element', () => {
+        const zone = createZone('z2');
+        zone.innerHTML = '<p>old content</p><p>more old content</p>';
+
+        registerComponent('clean', () => document.createElement('span'));
+        renderComponent({ type: 'clean', zone: 'z2' }, zone);
+
+        expect(zone.children).toHaveLength(1);
+        expect(zone.querySelector('p')).toBeNull();
+    });
+
+    test('throws when the component type has no registered builder', () => {
+        const zone = createZone('z3');
+        expect(() =>
+            renderComponent({ type: 'unregistered', zone: 'z3' }, zone)
+        ).toThrow(/unregistered/);
+    });
+
+    test('renders on every call (called multiple times, zone always has one child)', () => {
+        const zone = createZone('z4');
+        registerComponent('counter', makeBuilder('c'));
+
+        for (let i = 0; i < 5; i++) {
+            renderComponent({ type: 'counter', zone: 'z4' }, zone);
+            expect(zone.children).toHaveLength(1);
+        }
+    });
+});
+
+// ==============================================================================
+//                                SCHEDULE COMPONENT
+// ==============================================================================
+
+describe('scheduleComponent', () => {
+    test('does not render the component on call (bootstrap owns initial render)', () => {
+        const builder = jest.fn(() => document.createElement('div'));
+        registerComponent('imm', builder);
+
+        const zone = createZone('s1');
+        scheduleComponent({ type: 'imm', zone: 's1', refresh: 1000 }, zone, 'component-0');
+
+        expect(builder).toHaveBeenCalledTimes(0);
+        expect(zone.children).toHaveLength(0);
+    });
+
+    test('returns a handle with intervalId === null when no refresh is set', () => {
+        registerComponent('noref', () => document.createElement('div'));
+        const zone = createZone('s2');
+
+        const handle = scheduleComponent({ type: 'noref', zone: 's2' }, zone, 'component-0');
+
+        expect(handle.intervalId).toBeNull();
+        expect(typeof handle.cancel).toBe('function');
+    });
+
+    test('returns a handle with a numeric intervalId when refresh > 0', () => {
+        registerComponent('withref', () => document.createElement('div'));
+        const zone = createZone('s3');
+
+        const handle = scheduleComponent(
+            { type: 'withref', zone: 's3', refresh: 1000 },
+            zone,
+            'component-0'
+        );
+
+        expect(typeof handle.intervalId).toBe('number');
+        handle.cancel();
+    });
+
+    test('re-renders the component after each refresh interval elapses', () => {
+        const builder = jest.fn(() => document.createElement('span'));
+        registerComponent('tick', builder);
+        const zone = createZone('s4');
+
+        scheduleComponent({ type: 'tick', zone: 's4', refresh: 500 }, zone, 'component-0');
+        expect(builder).toHaveBeenCalledTimes(0); // bootstrap owns initial render
+
+        jest.advanceTimersByTime(500);
+        expect(builder).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(500);
+        expect(builder).toHaveBeenCalledTimes(2);
+
+        jest.advanceTimersByTime(1500); // 3 more ticks
+        expect(builder).toHaveBeenCalledTimes(5);
+    });
+
+    test('does NOT set an interval when refresh is 0', () => {
+        registerComponent('zero', () => document.createElement('div'));
+        const zone = createZone('s5');
+
+        const handle = scheduleComponent(
+            { type: 'zero', zone: 's5', refresh: 0 },
+            zone,
+            'component-0'
+        );
+
+        jest.advanceTimersByTime(10_000);
+        expect(handle.intervalId).toBeNull();
+    });
+
+    test('does NOT set an interval when refresh is negative', () => {
+        registerComponent('neg', () => document.createElement('div'));
+        const zone = createZone('s6');
+
+        const handle = scheduleComponent(
+            { type: 'neg', zone: 's6', refresh: -500 },
+            zone,
+            'component-0'
+        );
+
+        jest.advanceTimersByTime(10_000);
+        expect(handle.intervalId).toBeNull();
+    });
+
+    test('does NOT set an interval when refresh is a non-numeric string', () => {
+        registerComponent('str', () => document.createElement('div'));
+        const zone = createZone('s7');
+
+        const handle = scheduleComponent(
+            { type: 'str', zone: 's7', refresh: '1000' },
+            zone,
+            'component-0'
+        );
+
+        expect(handle.intervalId).toBeNull();
+    });
+
+    test('cancel() stops future re-renders', () => {
+        const builder = jest.fn(() => document.createElement('span'));
+        registerComponent('stoppable', builder);
+        const zone = createZone('s8');
+
+        const handle = scheduleComponent(
+            { type: 'stoppable', zone: 's8', refresh: 300 },
+            zone,
+            'component-0'
+        );
+
+        jest.advanceTimersByTime(300);
+        expect(builder).toHaveBeenCalledTimes(1); // 1 tick (no initial render)
+
+        handle.cancel();
+        jest.advanceTimersByTime(3000); // would fire 10 more times without cancel
+        expect(builder).toHaveBeenCalledTimes(1); // no additional renders
+    });
+
+    test('cancel() is safe to call multiple times (idempotent)', () => {
+        registerComponent('idm', () => document.createElement('div'));
+        const zone = createZone('s9');
+
+        const handle = scheduleComponent(
+            { type: 'idm', zone: 's9', refresh: 200 },
+            zone,
+            'component-0'
+        );
+
+        expect(() => {
+            handle.cancel();
+            handle.cancel();
+            handle.cancel();
+        }).not.toThrow();
+    });
+
+    test('cancel() on a no-refresh handle is a no-op', () => {
+        registerComponent('noop', () => document.createElement('div'));
+        const zone = createZone('s10');
+
+        const handle = scheduleComponent({ type: 'noop', zone: 's10' }, zone, 'component-0');
+
+        expect(() => handle.cancel()).not.toThrow();
+    });
+});
+
+// ==============================================================================
+//                                CANCEL ALL
+// ==============================================================================
+
+describe('cancelAll', () => {
+    test('stops all active intervals', () => {
+        const builder = jest.fn(() => document.createElement('div'));
+        registerComponent('ca', builder);
+
+        const zone1 = createZone('ca1');
+        const zone2 = createZone('ca2');
+
+        const h1 = scheduleComponent({ type: 'ca', zone: 'ca1', refresh: 200 }, zone1, 'component-0');
+        const h2 = scheduleComponent({ type: 'ca', zone: 'ca2', refresh: 200 }, zone2, 'component-1');
+
+        cancelAll([h1, h2]);
+        jest.advanceTimersByTime(2000);
+
+        expect(builder).toHaveBeenCalledTimes(0); // no renders — bootstrap owns initial render
+    });
+
+    test('is safe to call on an empty array', () => {
+        expect(() => cancelAll([])).not.toThrow();
+    });
+
+    test('is safe to call multiple times on the same handles', () => {
+        registerComponent('safe', () => document.createElement('div'));
+        const zone = createZone('ca3');
+
+        const handle = scheduleComponent({ type: 'safe', zone: 'ca3', refresh: 100 }, zone, 'component-0');
+
+        expect(() => {
+            cancelAll([handle]);
+            cancelAll([handle]);
+        }).not.toThrow();
+    });
+
+    test('handles without refresh intervals are cancelled without error', () => {
+        registerComponent('nointerval', () => document.createElement('div'));
+        const zone = createZone('ca4');
+
+        const handle = scheduleComponent({ type: 'nointerval', zone: 'ca4' }, zone, 'component-0');
+
+        expect(() => cancelAll([handle])).not.toThrow();
+    });
+
+    test('cancelling one handle does not affect others', () => {
+        const builder = jest.fn(() => document.createElement('span'));
+        registerComponent('ind', builder);
+
+        const zone1 = createZone('ca5');
+        const zone2 = createZone('ca6');
+
+        const h1 = scheduleComponent({ type: 'ind', zone: 'ca5', refresh: 300 }, zone1, 'component-0');
+        const h2 = scheduleComponent({ type: 'ind', zone: 'ca6', refresh: 300 }, zone2, 'component-1');
+
+        h1.cancel();
+        jest.advanceTimersByTime(900); // 3 ticks
+
+        // h1 cancelled, h2 fires 3 ticks
+        expect(builder).toHaveBeenCalledTimes(3);
+    });
+});


### PR DESCRIPTION
## Summary

- Bootstrap now owns the initial render of all components; scheduleComponent only sets up the refresh interval, not the first draw
- renderComponent targets each component by data-component-id instead of clearing the entire zone, allowing multiple components to share a zone without overwriting each other
- renderComponent is now async so both sync and async builders (e.g. weather) resolve correctly

## Changes Made
Scheduler can now replace individual components instead of the entire zone

## Testing
Scheduler now tested as async

## Definition of Done
- [x] No known defects
- [x] 90%+ unit test coverage
- [x] 100% JSDoc documented
- [x] User documentation up to date
- [x] Code reviewed via pull request